### PR TITLE
feat(ios): expose maxBufferSize to bound the animated-image frame buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,14 @@ In this case the image will still be styled and laid out the same way as `FastIm
 
 If supplied, changes the color of all the non-transparent pixels to the given color.
 
+---
+
+### `maxBufferSize?: number`
+
+**iOS only.** Maximum byte size of the decoded animated-image frame buffer (maps to SDWebImage's `SDAnimatedImageView.maxBufferSize`).
+
+`0` (the default) preserves SDWebImage's automatic behavior, which buffers as many decoded frames as memory allows. Set a small value (for example a few MB) to bound per-view memory when many animations are visible at once, trading some on-demand frame decoding for a constant memory ceiling. No-op on Android (Glide decodes animated frames on demand and has no equivalent buffer).
+
 ## Static Methods
 
 ### `FastImage.preload: (source[]) => void`

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewManager.java
@@ -83,6 +83,13 @@ class FastImageViewManager extends SimpleViewManager<FastImageViewWithUrl> imple
         view.setScaleType(scaleType);
     }
 
+    @ReactProp(name = "maxBufferSize")
+    public void setMaxBufferSize(FastImageViewWithUrl view, int maxBufferSize) {
+        // iOS-only (SDWebImage frame buffer). Glide decodes animated frames on
+        // demand with its own bitmap pool, so there is no equivalent buffer to
+        // cap. Accepted as a no-op so the cross-platform prop stays clean.
+    }
+
     @Override
     public void onDropViewInstance(@NonNull FastImageViewWithUrl view) {
         // This will cancel existing requests.

--- a/ios/FastImage/FFFastImageViewManager.m
+++ b/ios/FastImage/FFFastImageViewManager.m
@@ -22,6 +22,10 @@ RCT_EXPORT_VIEW_PROPERTY(onFastImageError, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onFastImageLoad, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onFastImageLoadEnd, RCTDirectEventBlock)
 RCT_REMAP_VIEW_PROPERTY(tintColor, imageColor, UIColor)
+// Bridges the inherited SDAnimatedImageView.maxBufferSize. 0 (default) keeps
+// SDWebImage's automatic frame-buffer sizing; a small value caps per-view
+// animated-image memory. See FastImageProps.maxBufferSize.
+RCT_EXPORT_VIEW_PROPERTY(maxBufferSize, NSUInteger)
 
 RCT_EXPORT_METHOD(preload:(nonnull NSArray<FFFastImageSource *> *)sources)
 {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -86,6 +86,20 @@ export interface FastImageProps extends AccessibilityProps, ViewProps {
     resizeMode?: ResizeMode
     fallback?: boolean
 
+    /**
+     * iOS only. Maximum byte size of the decoded animated-image frame buffer
+     * (maps to SDWebImage's `SDAnimatedImageView.maxBufferSize`).
+     *
+     * `0` (the default) preserves SDWebImage's automatic behavior, which buffers
+     * as many decoded frames as available memory allows. Set a small value (e.g.
+     * a few MB) to bound per-view memory when many animations are on screen at
+     * once, trading some on-demand frame decoding for a constant memory ceiling.
+     *
+     * No-op on Android (Glide decodes animated frames on demand and has no
+     * equivalent frame buffer).
+     */
+    maxBufferSize?: number
+
     onLoadStart?(): void
 
     onProgress?(event: OnProgressEvent): void
@@ -164,6 +178,7 @@ function FastImageBase({
     onLoadEnd,
     style,
     fallback,
+    maxBufferSize,
     children,
     // eslint-disable-next-line no-shadow
     resizeMode = 'cover',
@@ -211,6 +226,7 @@ function FastImageBase({
                 onFastImageError={onError}
                 onFastImageLoadEnd={onLoadEnd}
                 resizeMode={resizeMode}
+                maxBufferSize={maxBufferSize}
             />
             {children}
         </View>


### PR DESCRIPTION
## Why

`FFFastImageView` is an `SDAnimatedImageView`. By default `maxBufferSize = 0`, which lets SDWebImage buffer as many decoded frames as free memory allows. In a scrolling grid of animated GIF/WebP images, many views each buffer their full animation concurrently, which exhausts memory and crashes (`SDImageFramePool` frame decode leading to an OOM abort during the CoreAnimation commit). SDWebImage already supports bounding this via `maxBufferSize`, but FastImage never surfaced it.

## What

- **src:** add `maxBufferSize?: number` to `FastImageProps`, passed straight through to the native view.
- **iOS:** one `RCT_EXPORT_VIEW_PROPERTY(maxBufferSize, NSUInteger)` bridging the inherited `SDAnimatedImageView.maxBufferSize`. No view-subclass changes needed.
- **Android:** accepted as a documented no-op (Glide decodes animated frames on demand with its own bitmap pool, so there is no equivalent buffer to cap).
- **docs:** README prop entry, marked iOS-only.

## Compatibility

Default `0` preserves today's behavior exactly. Classic (Paper) view manager, no codegen or API changes. Setting a small value (for example a few MB) makes per-view RAM roughly constant regardless of frame count, trading a little on-demand decode CPU for a bounded memory ceiling.

## Testing

Render a grid of animated WebP/GIF with `maxBufferSize={4 * 1024 * 1024}` and confirm memory stays bounded during fast scroll while animation continues. With `0`/unset, behavior is unchanged.

## Notes for the publish/consumer side

- Version bump intentionally omitted; handle it via the release flow.
- The wallet app will pin the published version and set a small `maxBufferSize` on the chat media grid.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `maxBufferSize` property to configure animated image frame buffer sizing on iOS. Default value of `0` enables automatic buffering behavior. Property is available cross-platform for API consistency but only takes effect on iOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->