### PR TITLE
chore: add npm release workflow + bump to 8.6.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+# Publishes @phantom/react-native-fast-image to public npm. The @phantom scope is
+# public on npmjs.org (the wallet's Artifactory registry proxies it), so this mirrors
+# the publish setup used by phantom/react-native-webview, just triggered by a release
+# rather than changesets since this fork is bumped infrequently.
+#
+# To cut a release: bump "version" in package.json on main, then publish a GitHub
+# Release tagged v<version> (e.g. v8.6.6). This workflow publishes that version.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          registry-url: "https://registry.npmjs.org"
+          scope: "@phantom"
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - name: Publish
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN_PHANTOM_SECURITY_BOT }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@phantom/react-native-fast-image",
-    "version": "8.6.5",
+    "version": "8.6.6",
     "description": "🚩 FastImage, performant React Native image component.",
     "keywords": [
         "cache",


### PR DESCRIPTION
## What

- Adds `.github/workflows/release.yml` that publishes `@phantom/react-native-fast-image` to **public npm** on a GitHub Release (or manual `workflow_dispatch`), authenticated with `NPM_PUBLISH_TOKEN_PHANTOM_SECURITY_BOT` (the same npm publish token `phantom/react-native-webview` already uses).
- Bumps `version` `8.6.5 → 8.6.6` to ship the `maxBufferSize` prop merged in #2.

## Why

This repo had no working publish path: the old `ci.yml` / `dv-scripts` flow is dormant and is wired for public-npm semantics it never actually runs. The `@phantom` scope is public on npmjs.org, and the wallet's Artifactory registry proxies it, so publishing to public npm is the established pattern for these standalone RN forks (this mirrors `react-native-webview`). A Release-triggered workflow is used instead of changesets since this fork is bumped infrequently.

## Prerequisite

The repo needs access to the `NPM_PUBLISH_TOKEN_PHANTOM_SECURITY_BOT` secret (already used by `phantom/react-native-webview`). Once it's available to this repo:

1. Merge this PR.
2. Publish a GitHub Release tagged `v8.6.6`.
3. The workflow publishes `8.6.6` to npm.

Then Wallet pins `8.6.6` and sets `maxBufferSize` on the chat media grid.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 8.6.6
  * Added automated release workflow for npm publishing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->