### PR TITLE
ci: switch release workflow to npm Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,11 @@
 name: Release
 
-# Publishes @phantom/react-native-fast-image to public npm. The @phantom scope is
-# public on npmjs.org (the wallet's Artifactory registry proxies it), so this mirrors
-# the publish setup used by phantom/react-native-webview, just triggered by a release
-# rather than changesets since this fork is bumped infrequently.
+# Publishes @phantom/react-native-fast-image to public npm via npm Trusted Publishing
+# (keyless OIDC). Security enabled the Trusted Publisher for this repo + this workflow
+# file, so there is no NPM token to manage. Requires `id-token: write` and npm >= 11.5.1.
 #
 # To cut a release: bump "version" in package.json on main, then publish a GitHub
-# Release tagged v<version> (e.g. v8.6.6). This workflow publishes that version.
+# Release tagged v<version> (e.g. v8.6.6), or run this workflow manually.
 
 on:
   release:
@@ -15,6 +14,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:
@@ -26,8 +26,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20.x
-          registry-url: "https://registry.npmjs.org"
-          scope: "@phantom"
+
+      # Trusted Publishing (OIDC) requires npm >= 11.5.1; Node 20 ships npm 10.x.
+      - name: Upgrade npm
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -35,7 +37,6 @@ jobs:
       - name: Build
         run: yarn build
 
+      # No NODE_AUTH_TOKEN: npm exchanges the GitHub OIDC token via the Trusted Publisher.
       - name: Publish
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN_PHANTOM_SECURITY_BOT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,15 @@ jobs:
       - name: Build
         run: yarn build
 
+      # `dv-scripts build` resets package.json repository metadata to the upstream
+      # (DylanVann) repo, which fails Trusted Publishing provenance validation
+      # (provenance expects this repo). Re-assert it on the built package.json.
+      - name: Restore repository metadata for provenance
+        run: |
+          npm pkg set repository.type=git
+          npm pkg set repository.url=git+https://github.com/phantom/react-native-fast-image.git
+          npm pkg set homepage=https://github.com/phantom/react-native-fast-image#readme
+
       # No NODE_AUTH_TOKEN: npm exchanges the GitHub OIDC token via the Trusted Publisher.
       - name: Publish
         run: npm publish --access public

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
         "image",
         "priority"
     ],
-    "homepage": "https://github.com/DylanVann/react-native-fast-image#readme",
+    "homepage": "https://github.com/phantom/react-native-fast-image#readme",
     "bugs": {
-        "url": "https://github.com/DylanVann/react-native-fast-image/issues"
+        "url": "https://github.com/phantom/react-native-fast-image/issues"
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/DylanVann/react-native-fast-image.git"
+        "url": "git+https://github.com/phantom/react-native-fast-image.git"
     },
     "license": "(MIT AND Apache-2.0)",
     "author": "Dylan Vann <dylan@dylanvann.com> (https://dylanvann.com)",


### PR DESCRIPTION
Security enabled a Trusted Publisher for `phantom/react-native-fast-image` + `release.yml` (keyless OIDC). This switches the workflow to use it: adds `id-token: write`, removes the `NPM_PUBLISH_TOKEN` env, and upgrades npm to a Trusted-Publishing-capable version (>= 11.5.1). Unblocks publishing `8.6.6`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores / CI-CD
- Updated the npm publishing pipeline to use npm Trusted Publishing with GitHub OIDC (keyless), removing reliance on a stored publish token.
- Adjusted workflow permissions and publishing prerequisites, including an npm version update and improved provenance-related package metadata handling.

## Documentation
- Updated package links (homepage, bugs, and repository) to point to the correct GitHub repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->